### PR TITLE
Add check that Iterator returned by BulletList.children() is not null

### DIFF
--- a/src/pcminer/PCMiner.java
+++ b/src/pcminer/PCMiner.java
@@ -159,6 +159,8 @@ public class PCMiner {
               public void visitTag(Tag tag) {
                 if (tag instanceof BulletList) {
                   BulletList bl = (BulletList) tag;
+                  if (bl.getChildren() == null)
+                      return;
                   for (int i = 0; i < bl.getChildren().size(); i++) {
                     Node child = bl.childAt(i);
                     if (child instanceof TagNode) {

--- a/src/pcminer/PCMiner.java
+++ b/src/pcminer/PCMiner.java
@@ -159,8 +159,7 @@ public class PCMiner {
               public void visitTag(Tag tag) {
                 if (tag instanceof BulletList) {
                   BulletList bl = (BulletList) tag;
-                  if (bl.getChildren() == null)
-                      return;
+                  if (bl.getChildren() == null) return;
                   for (int i = 0; i < bl.getChildren().size(); i++) {
                     Node child = bl.childAt(i);
                     if (child instanceof TagNode) {


### PR DESCRIPTION
I'm not at all sure if this is the preferred solution, but it appears to work on newer DBLP HTML files.

The problem arises because the `Iterator` returned by `BulletList.children()` can be `null`. This seems like a bad thing for a library to do, but it is the current behavior of `htmlparser`. 

As a quick hack to fix PCMiner I simply added a `null` check and `return` from the visitor when extracting the data for papers in such cases.

Fixes #33 